### PR TITLE
Dodanie statystyki do panelu nawigacyjnego administratora systemu

### DIFF
--- a/WarsztatV2/WarsztatV2/Menu/Aktualnosci.xaml
+++ b/WarsztatV2/WarsztatV2/Menu/Aktualnosci.xaml
@@ -81,7 +81,7 @@
                                 <TextBlock Grid.Column="6" x:Name="day7n" Text="" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Grid>
                         </Grid>
-                        <Label x:Name="informationLabel1" Content="Oczekiwanie na pobranie danych ze serwera..." Margin="10,35,10,35" Grid.Row="1" FontStretch="Normal" HorizontalContentAlignment="Center"/>
+                        <Label x:Name="informationLabel1" Content="Oczekiwanie na pobranie danych ze serwera..." Margin="10,35,10,35" Grid.Row="1" FontStretch="Normal" HorizontalContentAlignment="Center" VerticalContentAlignment="Center"/>
                     </Grid>
                 </Border>
                 <Border x:Name="secondSection" Grid.Row="1" Background="#FFEEEEEE" Margin="10,0,10,10" CornerRadius="2">
@@ -138,20 +138,19 @@
                                 </Grid>
                             </Grid>
                         </Grid>
-                        <Label x:Name="informationLabel2" Content="Oczekiwanie na pobranie danych ze serwera..." Margin="10,10,10,110" Grid.Row="2" FontStretch="Normal" HorizontalContentAlignment="Center"/>
+                        <Label x:Name="informationLabel2" Content="Oczekiwanie na pobranie danych ze serwera..." Margin="10,10,10,80" Grid.Row="2" FontStretch="Normal" HorizontalContentAlignment="Center" VerticalContentAlignment="Center"/>
                     </Grid>
                 </Border>
             </Grid>
             <Grid Grid.Column="1" Margin="0,0,10,0">
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="300"/>
+                    <RowDefinition Height="150"/>
+                    <RowDefinition Height="150"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
                 <Border x:Name="thirdSection" Grid.Row="0" Background="#FFEEEEEE" Margin="0,10,15,10" CornerRadius="2">
                     <Grid>
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="45"/>
-                            <RowDefinition Height="*"/>
                             <RowDefinition Height="45"/>
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
@@ -173,11 +172,7 @@
                                 </Grid>
                             </Grid>
                         </Grid>
-                        <TextBlock Grid.Row="2" x:Name="thirdSubSectionHeader2" Text="Przyczyna ostatniej wizyty" Margin="0,10,0,0" FontSize="16" HorizontalAlignment="Center" VerticalAlignment="Top" TextWrapping="Wrap" Height="43" Width="406" Grid.RowSpan="2"/>
-                        <Grid Grid.Row="3" Margin="10,0,10,10">
-                            <TextBlock x:Name="reasonText" TextWrapping="Wrap"/>
-                        </Grid>
-                        <Label x:Name="informationLabel3" Content="Oczekiwanie na pobranie danych ze serwera..." Margin="8,32,13,31" FontStretch="Normal" HorizontalContentAlignment="Center" Grid.Row="1"/>
+                        <Label x:Name="informationLabel3" Content="Oczekiwanie na pobranie danych ze serwera..." Margin="10,10,10,10" FontStretch="Normal" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Grid.Row="1"/>
                     </Grid>
                 </Border>
                 <Border x:Name="fourthSection" Grid.Row="1" Background="#FFEEEEEE" Margin="0,0,15,10" CornerRadius="2">
@@ -212,7 +207,23 @@
                                 </Grid>
                             </Grid>
                         </Grid>
-                        <Label x:Name="informationLabel4" Content="Oczekiwanie na pobranie danych ze serwera..." Margin="8,56,13,56" Grid.Row="1" FontStretch="Normal" HorizontalContentAlignment="Center"/>
+                        <Label x:Name="informationLabel4" Content="Oczekiwanie na pobranie danych ze serwera..." Margin="10,10,10,10" Grid.Row="1" FontStretch="Normal" HorizontalContentAlignment="Center" VerticalContentAlignment="Center"/>
+                    </Grid>
+                </Border>
+                <Border x:Name="fifthSection" Grid.Row="3" Background="#FFEEEEEE" Margin="0,0,15,10" CornerRadius="2">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="45"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <TextBlock Grid.Row="0" x:Name="fifthSubSectionHeader1" Text="Średni czas obsługi pojazdu" Margin="0,10,0,0" FontSize="16" HorizontalAlignment="Center" VerticalAlignment="Top" TextWrapping="Wrap" Height="43" Width="406" Grid.RowSpan="2"/>
+                        <Grid Grid.Row="1" Margin="10,0,10,10">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock x:Name="averageTime" Grid.Row="0" Text="" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="64" Foreground="Firebrick" FontWeight="Bold"/>
+                        </Grid>
+                        <Label x:Name="informationLabel5" Content="Oczekiwanie na pobranie danych ze serwera..." Margin="10,35,10,35" FontStretch="Normal" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Grid.Row="1"/>
                     </Grid>
                 </Border>
             </Grid>


### PR DESCRIPTION
Statystyka związana jest z określoną na platformie Trello funkcjonalności związanej z wyświetleniem informacji dotyczącej średniego czasu przebywania pojazdu we warsztacie od przyjęcia zgłoszenia do wydania pojazdu.